### PR TITLE
Integrating configsuite schema to stea config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ project-version: 1
 # All information in stea is versioned with a timestamp. When we request a 
 # calculation we must specify wich date we wish to use to fetch configuration 
 # information for assumptions like e.g. the oil price.
-config-date: 2018-07-01
+config-date: 2018-07-01 12:00:00
 
 
 # The stea web client works by *adjusting* the profiles in an existing
@@ -53,7 +53,7 @@ ecl-profiles:
      
   profile_comment_in_stea:
      ecl-key: FWPT
-     mult: 1.1
+     glob_mult: 1.1
 
   another_profile_comment_in_stea:
      ecl-key: FWPT
@@ -77,10 +77,12 @@ import sys
 import stea
 
 def main(argv):
-    if len(argv) < 1:
-       sys.exit("Need yaml formatted configuration file as first commandline argument")
+     if len(argv) == 2:
+        fname = argv[1]
+    else:
+        raise AttributeError('Need yaml formatted configuration file as first commandline argument')
     
-    stea_input = stea.SteaInput(sys.argv[1:])
+    stea_input = stea.SteaInput([fname])
     res = stea.calculate(stea_input)
     for res,value in res.results(stea.SteaKeys.CORPORATE).items():
         print("{res} : {value}".format(res=res, value=value)) 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,6 @@
 
 requests
 pyyaml
+configsuite
 
 

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,6 @@ setup(name='stea',
       setup_requires=['setuptools_scm'],
       use_scm_version={'write_to' : 'stea/version.py'},
       platforms='any',
-      install_requires=['requests','pyyaml'],
+      install_requires=['requests','pyyaml','configsuite'],
       test_suite='tests.suite',
 )

--- a/stea/stea_config.py
+++ b/stea/stea_config.py
@@ -1,0 +1,143 @@
+import configsuite
+from configsuite import MetaKeys as MK
+from configsuite import types
+
+@configsuite.transformation_msg("Fix key names by replacing: `-` with `_`")
+def _fix_keys(elem):
+    fix_dict = {}
+    for key in elem:
+        new_key = str(key).replace('-','_')
+        print('Replacing {} with {}'.format(key, new_key))
+        fix_dict[new_key] = elem.get(key)
+    return fix_dict
+
+def _build_schema():
+    return {
+        MK.Type: types.NamedDict,
+        MK.LayerTransformation: _fix_keys,
+        MK.Content: {
+            'project_id': {
+                MK.Type: types.Number,
+                MK.Description: ("The id (a number) of the project, which must already exist and be available in"
+                                 "the stea database. In the Stea documentation this is called 'AlternativeId'"),
+                MK.Required: True
+            },
+            'project_version': {
+                MK.Type: types.Number,
+                MK.Description: "Project alternative version number that comes from stea database",
+                MK.Required: True
+            },
+            'config_date': {
+                MK.Type: types.DateTime,
+                MK.Description: "timestamp: Y-M-D H:M:S that comes with stea request",
+                MK.Required: True
+            },
+            'profiles': {
+                MK.Type: types.Dict,
+                MK.Description: ("The profiles keyword is used to enter profile data explicitly in the"
+                                "configuration file. Each profile is identified with an id from the"
+                                "existing stea project, a start year and the actual data"),
+                MK.Required: False,
+                MK.Content: {
+                    MK.Key: {MK.Type: types.String},
+                    MK.Value: {
+                        MK.Type: types.NamedDict,
+                        MK.LayerTransformation: _fix_keys,
+                        MK.Required: False,
+                        MK.Content: {
+                            'start_year': {
+                                MK.Type: types.Integer,
+                                MK.Description: "Start year (an Integer)",
+                                MK.Required: False
+                            },
+                            'data': {
+                                MK.Type: types.List,
+                                MK.Description: "Values",
+                                MK.Required: False,
+                                MK.Content: {
+                                    MK.Item: {MK.Type: types.Number}
+                                }
+                            }
+                        }
+                    }
+                }
+            },
+            'ecl_profiles': {
+                MK.Type: types.Dict,
+                MK.Description: ("Profiles which are calculated directly from an eclipse simulation."
+                                 "They are listed with the ecl-profiles ecl_key."),
+                MK.Required: True,
+                MK.Content: {
+                    MK.Key: {MK.Type: types.String},
+                    MK.Value: {
+                        MK.Type: types.NamedDict,
+                        MK.LayerTransformation: _fix_keys,
+                        MK.Required: True,
+                        MK.Content: {
+                            'ecl_key': {
+                                MK.Type: types.String,
+                                MK.Description: "Summary key",
+                                MK.Required: True
+                            },
+                            'start_year': {
+                                MK.Type: types.Integer,
+                                MK.Description: ("By default the stea"
+                                                "client will calculate a profile from the full time range of the simulated"
+                                                "data, but you can optionally use the keywords start-year and end-year to"
+                                                "limit the time range."),
+                                MK.Required: False
+                            },
+                            'end_year': {
+                                MK.Type: types.Integer,
+                                MK.Description: ("By default the stea"
+                                                "client will calculate a profile from the full time range of the simulated"
+                                                "data, but you can optionally use the keywords start-year and end-year to"
+                                                "limit the time range."),
+                                MK.Required: False
+                            },
+                            'mult': {
+                                MK.Type: types.List,
+                                MK.Required: False,
+                                MK.Description: "List of multipliers of eclsum key",
+                                MK.Content: {
+                                    MK.Item: {
+                                        MK.Type: types.Number
+                                    }
+                                }
+                            },
+                            'glob_mult': {
+                                MK.Type: types.Number,
+                                MK.Required: False,
+                                MK.Description: "A single global multiplier of eclsum key",
+                                MK.Content: {
+                                    MK.Item: {
+                                        MK.Type: types.Integer
+                                    }
+                                }
+                            },
+                        }
+                    }
+                }
+            },
+            'stea_server': {
+               MK.Type: types.String,
+               MK.Description: "stea server host.",
+               MK.Required: False
+            },
+            'ecl_case': {
+                MK.Type: types.String,
+                MK.Description: "ecl case location",
+                MK.Required: False
+            },
+            'results': {
+                MK.Type: types.List,
+                MK.Description: ("Specify what STEA should calculate"),
+                MK.Required: True,
+                MK.Content: {
+                    MK.Item: {
+                        MK.Type: types.String
+                    }
+                }
+            },
+        },
+    }

--- a/stea/stea_keys.py
+++ b/stea/stea_keys.py
@@ -23,22 +23,22 @@ class SteaKeys(object):
     PRETAX          = "Pretax"
     CORPORATE       = "Corporate"
 
-
 class SteaInputKeys(object):
     """The SteaInputKeys contains string constants used as keys in the
     configuration file used by the local stea client.
     """
-    CONFIG_DATE     = "config-date"
-    PROJECT_ID      = "project-id"
-    PROJECT_VERSION = "project-version"
+    CONFIG_DATE     = "config_date"
+    PROJECT_ID      = "project_id"
+    PROJECT_VERSION = "project_version"
     RESULTS         = "results"
-    ECL_PROFILES    = "ecl-profiles"
-    ECL_CASE        = "ecl-case"
-    ECL_KEY         = "ecl-key"
-    ECL_MULT        = "mult"		
-    SERVER          = "stea-server"
-    START_YEAR      = "start-year"
-    END_YEAR        = "end-year"
+    ECL_PROFILES    = "ecl_profiles"
+    ECL_CASE        = "ecl_case"
+    ECL_KEY         = "ecl_key"
+    ECL_MULT        = "mult"
+    ECL_GLOB_MULT   = "glob_mult"
+    SERVER          = "stea_server"
+    START_YEAR      = "start_year"
+    END_YEAR        = "end_year"
     PROFILES        = "profiles"
     DATA            = "data"
     PROFILE_KEY     = "Description"

--- a/tests/test_stea.py
+++ b/tests/test_stea.py
@@ -5,7 +5,7 @@ import subprocess
 import datetime
 import requests
 from requests.exceptions import ConnectionError
-from stea import calculate, SteaClient, SteaRequest, SteaProject, SteaInput, SteaKeys, SteaInputKeys, SteaResult
+from stea import calculate, SteaClient, SteaRequest, SteaProject, SteaInput, SteaInputKeys, SteaKeys, SteaResult
 
 from ecl.util.test.ecl_mock import createEclSum
 from ecl.util.test import TestAreaContext
@@ -122,8 +122,8 @@ class SteaTest(unittest.TestCase):
 
 
             with open("config_file","w") as f:
-                f.write("{}: 2018-10-10\n".format(SteaInputKeys.CONFIG_DATE))
-                f.write("{}: abc100\n".format(SteaInputKeys.PROJECT_ID))
+                f.write("{}: 2018-10-10 12:00:00\n".format(SteaInputKeys.CONFIG_DATE))
+                f.write("{}: 1234\n".format(SteaInputKeys.PROJECT_ID))
                 f.write("{}: 1\n".format(SteaInputKeys.PROJECT_VERSION))
 
                 f.write("{}: \n".format(SteaInputKeys.ECL_PROFILES))
@@ -135,12 +135,13 @@ class SteaTest(unittest.TestCase):
                 f.write("   - npv\n")
 
             stea_input = SteaInput(["config_file"])
-            self.assertEqual(stea_input.config_date, datetime.datetime(2018,10,10))
-            self.assertEqual(stea_input.project_id, "abc100")
+            self.assertEqual(stea_input.config_date, datetime.datetime(2018, 10, 10, 12, 0, 0))
+            self.assertEqual(stea_input.project_id, 1234)
             self.assertEqual(stea_input.project_version, 1)
             self.assertEqual(2, len(stea_input.ecl_profiles))
-            self.assertIn("ID1", stea_input.ecl_profiles)
-            self.assertIn("ID2", stea_input.ecl_profiles)
+            keys = [key[0] for key in stea_input.ecl_profiles]
+            self.assertTrue('ID1' in keys)
+            self.assertTrue('ID2' in keys)
 
             with open("config_file","w") as f:
                 f.write("{}: No-not-a-date".format(SteaInputKeys.CONFIG_DATE))
@@ -152,8 +153,8 @@ class SteaTest(unittest.TestCase):
         with TestAreaContext("stea_input_argv"):
 
             with open("config_file","w") as f:
-                f.write("{}: 2018-10-10\n".format(SteaInputKeys.CONFIG_DATE))
-                f.write("{}: abc100\n".format(SteaInputKeys.PROJECT_ID))
+                f.write("{}: 2018-10-10 12:00:00\n".format(SteaInputKeys.CONFIG_DATE))
+                f.write("{}: 1234\n".format(SteaInputKeys.PROJECT_ID))
                 f.write("{}: 1\n".format(SteaInputKeys.PROJECT_VERSION))
 
                 f.write("{}: \n".format(SteaInputKeys.ECL_PROFILES))
@@ -175,8 +176,8 @@ class SteaTest(unittest.TestCase):
     def test_request1(self):
         with TestAreaContext("stea_request"):
             with open("config_file","w") as f:
-                f.write("{}: 2018-10-10\n".format(SteaInputKeys.CONFIG_DATE))
-                f.write("{}: abc100\n".format(SteaInputKeys.PROJECT_ID))
+                f.write("{}: 2018-10-10 12:00:00\n".format(SteaInputKeys.CONFIG_DATE))
+                f.write("{}: 1234\n".format(SteaInputKeys.PROJECT_ID))
                 f.write("{}: 1\n".format(SteaInputKeys.PROJECT_VERSION))
 
                 f.write("{}: \n".format(SteaInputKeys.ECL_PROFILES))
@@ -204,8 +205,8 @@ class SteaTest(unittest.TestCase):
             case = create_case()
             case.fwrite()
             with open("config_file","w") as f:
-                f.write("{}: 2018-10-10\n".format(SteaInputKeys.CONFIG_DATE))
-                f.write("{}: abc100\n".format(SteaInputKeys.PROJECT_ID))
+                f.write("{}: 2018-10-10 12:00:00\n".format(SteaInputKeys.CONFIG_DATE))
+                f.write("{}: 1234\n".format(SteaInputKeys.PROJECT_ID))
                 f.write("{}: 1\n".format(SteaInputKeys.PROJECT_VERSION))
 
                 f.write("{}: \n".format(SteaInputKeys.ECL_PROFILES))
@@ -247,6 +248,8 @@ class SteaTest(unittest.TestCase):
 
             stea_input = SteaInput(["config_file"])
             results = calculate(stea_input)
+            for res, value in results.results(SteaKeys.CORPORATE).items():
+                print('DBG_TEST {}, {}'.format(res, value))
 
 
     def test_results(self):


### PR DESCRIPTION
The schema is implemented `stea_config.py`, which also contains transformation necessary to accept keys. In the config file the main change is  that when ecl key `multiplier` is only a number it is now represented as `glob_mult` and if it is a list of mulitplies it remains the same, i.e. `mult`.
Additionally: `config-date` or `config_date` needs to be a full UTC timestamp, e.g., 2019-1-1 08:00:00