### PR TITLE
Use DNS alias for production server

### DIFF
--- a/stea/stea_input.py
+++ b/stea/stea_input.py
@@ -6,6 +6,7 @@ import configsuite
 import yaml
 
 from .stea_config import _build_schema
+from .stea_keys import SteaKeys
 
 try:
     from ecl.summary import EclSum
@@ -44,7 +45,7 @@ class SteaInput:
 
         try:
             schema = _build_schema()
-            defaults = {"stea_server": "https://ws2291.statoil.net"}
+            defaults = {"stea_server": SteaKeys.PRODUCTION_SERVER}
             with open(args.config_file, "r", encoding="utf-8") as config_file:
                 config_dict = yaml.safe_load(config_file)
 

--- a/stea/stea_keys.py
+++ b/stea/stea_keys.py
@@ -1,9 +1,12 @@
 # pylint: disable=too-few-public-methods
+
+
 class SteaKeys:
     """The SteaKeys class contains string constants which are used in HTTP
     communication with the stea web service.
     """
 
+    PRODUCTION_SERVER = "stea-fmu.equinor.com"
     PROJECT_VERSION = "AlternativeVersion"
     PROJECT_ID = "AlternativeId"
     PROFILES = "Profiles"


### PR DESCRIPTION
<on-prem>$ host stea-fmu.equinor.com
stea-fmu.equinor.com is an alias for WS2291.statoil.net.
WS2291.statoil.net has address 136.164.38.16